### PR TITLE
Expand README.md website concepts section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,31 +6,36 @@ campusdata.github.io
 
 ######Publicity
 - Let people know we exist / that we are doing this at our schools
+- Showcase effective examples of Open Data (on Campuses or otherwise)
 
 ######Dialogue about Campus Data
 - We are starting a dialogue with others
 - Allow other members to contribute content to the site, and allow people to see what others are doing
 - People from other schools would submit content through a form
 
+######Boilerplate / QuickStart Resources
+- Provide raw template code / action plans that can be used to demonstrate to local admin the value of Open Data
+- Write tutorials to make it easy for beginning programmers to get excited about working with APIs
+
 ###Site Goals
 1. Convey our mission
 2. Who's involved
 3. How to join the community
 4. Examples of Success
-	- stories of impact
+	- Stories of impact
 	- APIs
 5. Links to resources (Largely non-technical)
 6. Education / Contribution
 7. Inspire people to read the guide
 
 ###Problems we are trying to solve
-1. Poeple don't know they can make an impact
+1. People don't know they can make an impact
 2. People don't know others are thinking about this issue
 	- Students (Chief focus)
 	- University Administrators
 3. Students aren't aware of the OpenData efforts happening at their schools
 	
 ###Ways to join the community
-1. ListServ
-2. Form 
+1. [ListServ](http://campusdata.us7.list-manage1.com/subscribe/post?u=18ba658e22c34b6ac8bac552f&id=9b7a676140)
+2. [Form](https://docs.google.com/forms/d/1y6_dOgwXQ2Il_zi0_E6QelTX_q0tnGF1QvEP5l4_zjU/viewform) 
 


### PR DESCRIPTION
Minor typo fixes + move concepts from initiatives doc to github readme

(Didn't realize earlier that the branch head migrated from my forked copy to the actual site, so documenting of changes goofed up a bit. Won't happen again.)

