### PR TITLE
Add new Cobalt APIs to UofT's rankings

### DIFF
--- a/_data/rankings.yml
+++ b/_data/rankings.yml
@@ -40,7 +40,7 @@
   hackathon:
     name: "YHack"
     url: "http://www.yhack.org/"
-  api: 
+  api:
     name: Student Developer Portal
     url: "https://developers.yale.edu/documentation"
   open_data_group: null
@@ -196,7 +196,7 @@
   api:
     name: "umd.io"
     url: "http://umd.io"
-  open_data_group: 
+  open_data_group:
     name: "Startup Shell"
     url: "http://startupshell.org/"
   apis:
@@ -525,7 +525,7 @@
     athletics: false
     buildings: true
     courses: true
-    dining: false
+    dining: true
     events: false
     housing: false
     library: false
@@ -533,7 +533,7 @@
     news: false
     people: false
     printers: false
-    textbooks: false
+    textbooks: true
     transit: false
     weather: false
     extras: null


### PR DESCRIPTION
Cobalt launched 2 more APIs this week from fellow contributors. Keeping CampusData up to date!