### PR TITLE
Update UofT's rankings with updated data

### DIFF
--- a/_data/rankings.yml
+++ b/_data/rankings.yml
@@ -32,6 +32,40 @@
       - "goosewatch"
 
 - university:
+    name: "University of Toronto"
+    url: "https://utoronto.ca"
+  student_group:
+    name: "CSSU"
+    url: "https://cssu.ca"
+  hackathon:
+    name: "UofTHacks"
+    url: "https://uofthacks.com"
+  api:
+    name: "Cobalt APIs"
+    url: "https://cobalt.qas.im"
+  open_data_group:
+    name: "Cobalt"
+    url: "https://github.com/cobalt-uoft"
+  apis:
+    athletics: true
+    buildings: true
+    courses: true
+    dining: true
+    events: true
+    housing: false
+    library: true
+    map: true
+    news: false
+    people: false
+    printers: false
+    textbooks: true
+    transit: true
+    weather: false
+    extras:
+      - "vehicle parking"
+      - "bicycle racks"
+
+- university:
     name: "Yale University"
     url: "http://www.yale.edu/"
   student_group:
@@ -506,34 +540,6 @@
     people: false
     printers: false
     textbooks: false
-    transit: false
-    weather: false
-    extras: null
-
-- university:
-    name: "University of Toronto"
-    url: "https://www.utoronto.ca"
-  student_group: null
-  hackathon:
-    name: "UofTHacks"
-    url: "https://uofthacks.com"
-  api:
-    name: "Cobalt"
-    url: "https://cobalt.qas.im/"
-  open_data_group: null
-  apis:
-    athletics: false
-    buildings: true
-    courses: true
-    dining: true
-    events: false
-    housing: false
-    library: false
-    map: true
-    news: false
-    people: false
-    printers: false
-    textbooks: true
     transit: false
     weather: false
     extras: null


### PR DESCRIPTION
Cobalt initiative at the University of Toronto has recently made a huge push to introduce a handful of new datasets!

They are publicly available here: https://github.com/cobalt-uoft/datasets

We hope to have our first endpoint with cooperation from an official UofT department this summer (our numbers have grown, and the administration has finally decided to respond to our inquiries at last). A thank you to Campus Data for the advice we have used to reach this far.

I've also re-ordered the rankings by number of checkmarks in this PR.