### PR TITLE
Feature/remove ucsd clone and add vanderbilt

### DIFF
--- a/_data/rankings.yml
+++ b/_data/rankings.yml
@@ -369,6 +369,32 @@
     extras: null
 
 - university:
+    name: "Vanderbilt University"
+    url: "https://www.vanderbilt.edu"
+  student_group: null
+  hackathon:
+    name: "VandyHacks"
+    url: "https://vandyhacks.org"
+  api: null
+  open_data_group: null
+  apis:
+    athletics: false
+    buildings: false
+    courses: false
+    dining: false
+    events: true  # https://events.vanderbilt.edu/index.php?com=tools
+    housing: false
+    library: false
+    map: false
+    news: false
+    people: false
+    printers: false
+    textbooks: false
+    transit: false
+    weather: false
+    extras: null
+
+- university:
     name: "Duke University"
     url: "https://duke.edu/"
   student_group: null

--- a/_data/rankings.yml
+++ b/_data/rankings.yml
@@ -577,32 +577,6 @@
     extras: null
 
 - university:
-    name: "UC San Diego"
-    url: "https://ucsd.edu/"
-  student_group: null
-  hackathon:
-    name: "SD Hacks"
-    url: "https://sdhacks.io"
-  api: null
-  open_data_group: null
-  apis:
-    athletics: false
-    buildings: false
-    courses: false
-    dining: false
-    events: false
-    housing: false
-    library: false
-    map: false
-    news: false
-    people: false
-    printers: false
-    textbooks: false
-    transit: false
-    weather: false
-    extras: null
-
-- university:
     name: "University of Kentucky Louisville"
     url: "https://www.louisville.edu"
   student_group: null

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -44,7 +44,7 @@
   </div>
   <div class="footer-copyright">
     <div class="container">
-      © 2015 Campus Data
+      © 2017 Campus Data
       <a class="grey-text text-lighten-4 right" href="https://github.com/CampusData/campusdata.github.io"><i class="fa fa-github"></i>  Campus Data on GitHub</a>
     </div>
   </div>


### PR DESCRIPTION
- Fixes #48, Fixes #49 
- Additionally, updates the year in the site footer in https://github.com/CampusData/campusdata.github.io/pull/50/commits/73f04da63311b2421bcc7913fbf16d9911b53840, didn't seem like a big enough to change to warrant opening a new issue / PR for.