### PR TITLE
Delete CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-campusdata.org


### PR DESCRIPTION
campusdata.org was purchased by some scammer selling viagra... so I'm removing the redirect.